### PR TITLE
Non boolean values are accepted and they break UI

### DIFF
--- a/packages/boolean/lib/input.js
+++ b/packages/boolean/lib/input.js
@@ -5,7 +5,12 @@ export default Component.extend({
 
   classNameBindings: [ 'value:true:false', 'disabled' ],
 
-  value: null,
+  // Ensure that the value is always a boolean
+  // Returns the value when the computed property is cached.
+  // Returns false when the cache is empty
+  value: function(key, value) {
+    return arguments.length === 1 ? false : !!value;
+  }.property(),
 
   disabled: false,
 

--- a/packages/boolean/tests/main.js
+++ b/packages/boolean/tests/main.js
@@ -10,6 +10,19 @@ var template1 = compileTemplate(function() {/*
   {{#boolean-input-false class="false"}}Awwwwww{{/boolean-input-false}}
 */});
 
+test("component value is false by default", function() {
+  var defaultComponent = buildComponent(this);
+  strictEqual(defaultComponent.get('value'), false, "value is false when no value is provided");
+})
+
+test("component always has a boolean value", function() {
+  var component = buildComponent(this, { value: null });
+  strictEqual(component.get('value'), false, "value is false even though it was set as `null`");
+
+  Ember.run(component, 'set', 'value', 'truthy');
+  strictEqual(component.get('value'), true, "value is true even though it was set as `'truthy'`");
+});
+
 test("clicking the component toggles the value attribute", function() {
   var component = buildComponent(this);
 


### PR DESCRIPTION
The boolean input component should only ever have the value of `true` or `false`. This means type-checking on value set, and changing the default from `null` to `false`.
