### PR TITLE
Allow for aligning popovers to their parent

### DIFF
--- a/examples/tip.html
+++ b/examples/tip.html
@@ -10,6 +10,13 @@
   p {
     margin: 3em;
   }
+  strong {
+    color: black;
+  }
+  .spacer p {
+    margin: 0.5em;
+    text-align: center;
+  }
   lio-popover {
     position: absolute;
     pointer-events: none;
@@ -65,8 +72,15 @@
     border-bottom-color: #000;
   }
   .box {
-    background: rgba(255, 50, 200, 0.3);
-    padding: 10px;
+    position: relative;
+    border: 1px dotted #333;
+    height: 400px;
+    margin: 2em;
+  }
+  .inner-box {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
   }
 </style>
 
@@ -94,6 +108,54 @@
   odio tortor, ac fringilla odio dictum a. Pellentesque molestie lobortis nisi a faucibus. Donec at sapien sed dui malesuada aliquet. Donec neque felis, faucibus vitae lorem sit amet, aliquet vulputate diam. Fusce ut auctor ipsum. Proin porttitor dapibus eros vel placerat. Duis id dui euismod, euismod ante ut, mattis urna. Quisque semper eros nec turpis adipiscing tempus vel sit amet quam. Fusce vestibulum urna ac eros commodo, vitae tristique metus luctus. Etiam sit amet sollicitudin purus. Maecenas nec rhoncus metus. Cras sit amet tempor eros, at cursus est. Nullam pellentesque orci et tellus luctus cursus. Nullam pulvinar fermentum ante, a feugiat mauris fringilla quis.</p>
 
 <p>Cras id congue purus, sed porttitor augue. Aenean in tortor nulla. Pellentesque aliquet suscipit lectus, consequat fringilla urna tempus non. Duis sit amet velit eget nisl imperdiet porttitor. Nunc ut sodales ante. Cras porttitor mauris in leo congue malesuada. In hac habitasse platea dictumst. Praesent aliquet, est non euismod aliquet, velit neque aliquet nisi, in varius ipsum quam sit amet lacus. Cras non interdum metus, at feugiat elit. Morbi fringilla vehicula neque vitae tristique. Vestibulum eu nulla tincidunt, convallis leo a, sollicitudin ipsum. Aliquam arcu nisl, mattis nec mi in, porta ullamcorper sapien. Mauris nulla arcu, condimentum non velit a, varius condimentum libero.</p>
+
+<div class="spacer">
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p><strong><em>scroll to the next example</em></strong></p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+  <p>&middot;</p>
+</div>
+
+<div class="box">
+  <div class="inner-box">
+  <p>In et lacus augue.
+      {{#lio-tip activator="hover"}}
+        {{#lio-label}}
+          <cite tabindex=1>Fusce et tempus nunc, ac feugiat leo. Curabitur dignissim</cite>
+        {{/lio-label}}
+        {{#lio-popover position="right"}}
+          I am not sure what that means. Sorry.
+        {{/lio-popover}}
+      {{/lio-tip}}
+    odio tortor, ac fringilla odio dictum a. Pellentesque molestie lobortis nisi a faucibus. Donec at sapien sed dui malesuada aliquet. Donec neque felis, faucibus vitae lorem sit amet, aliquet vulputate diam. Fusce ut auctor ipsum. Proin porttitor dapibus eros vel placerat. Duis id dui euismod, euismod ante ut, mattis urna. Quisque semper eros nec turpis adipiscing tempus vel sit amet quam. Fusce vestibulum urna ac eros commodo, vitae tristique metus luctus. Etiam sit amet sollicitudin purus. Maecenas nec rhoncus metus. Cras sit amet tempor eros, at cursus est. Nullam pellentesque orci et tellus luctus cursus. Nullam pulvinar fermentum ante, a feugiat mauris fringilla quis.</p>
+  </div>
+</div>
 </script>
 
 <script src="../bower_components/jquery/dist/jquery.js"></script>

--- a/packages/display/lib/popover.js
+++ b/packages/display/lib/popover.js
@@ -45,6 +45,8 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
 
   anchor: null,
 
+  alignToParent: false,
+
   //
   // Internal Properties
   //
@@ -153,7 +155,8 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
       var $el = this.$();
       var $arrow = $el.find('.arrow');
       var $anchor = $(get(this, 'anchor'));
-      var anchorOffset = $anchor.offset() || { top: 0, left: 0 };
+      var anchorOffset = get(this, 'alignToParent') ? $anchor.position() : $anchor.offset();
+      anchorOffset = anchorOffset || { top: 0, left: 0 };
 
       setProperties(this, {
         offsetTop: anchorOffset.top,

--- a/packages/display/lib/tip.js
+++ b/packages/display/lib/tip.js
@@ -117,5 +117,6 @@ export default Component.extend(ParentComponentMixin, ActiveStateMixin, {
     assert(String.fmt("The '%@' component must have a single 'lio-label' and a single 'lio-popover'", [ get(this, 'tagName') ]), labelsLength === 1 && popoversLength === 1);
 
     set(get(this, 'popover'), 'anchor', get(this, 'label').$());
+    set(get(this, 'popover'), 'alignToParent', true);
   }.on('didRegisterComponents')
 });


### PR DESCRIPTION
By default, popovers align to the window. Sometimes it is
desired to have the popover align to its parent.

Now popovers can be described like this:

``` hbs
{{#lio-popover alignToParent=true}}
  Awwwww yissssssssssssssss
{{/lio-popover}}
```

This is also configured to be true automatically for `lio-tip` since the popover is always within the tip.
