### PR TITLE
Toggle component accepts a value of null but doesn't render anything

### DIFF
--- a/packages/input/lib/toggle.js
+++ b/packages/input/lib/toggle.js
@@ -6,7 +6,8 @@ import {
   set,
   run,
   computed,
-  assert
+  assert,
+  isNone
 } from 'ember';
 
 var typeKey = 'toggle';
@@ -114,7 +115,7 @@ export default Component.extend(ParentComponentMixin, {
     var defaultValue = get(this, 'defaultValue');
 
     // Only set the default if there's currently no value
-    if (value === undefined && defaultValue !== undefined) {
+    if (isNone(value) && !isNone(defaultValue)) {
       set(this, 'value', defaultValue);
     }
   }.on('didRegisterComponents')

--- a/packages/input/tests/toggle.js
+++ b/packages/input/tests/toggle.js
@@ -110,6 +110,36 @@ test("the value defaults to the `defaultValue` attribute when there is not value
   equal(component.get('value'), true, "value is initially set to default");
 });
 
+test("the value defaults to the `defaultValue` attribute when its bound value is undefined", function() {
+  var contextObject = Ember.Object.create({
+    value: undefined
+  });
+
+  var component = buildComponent(this, {
+    template: template1,
+    defaultValue: false,
+    contextObject: contextObject,
+    valueBinding: 'contextObject.value'
+  });
+
+  equal(contextObject.get('value'), false, "value is set to default when value is undefined");
+});
+
+test("the value defaults to the `defaultValue` attribute when its bound value is null", function() {
+  var contextObject = Ember.Object.create({
+    value: null
+  });
+
+  var component = buildComponent(this, {
+    template: template1,
+    defaultValue: false,
+    contextObject: contextObject,
+    valueBinding: 'contextObject.value'
+  });
+
+  equal(contextObject.get('value'), false, "value is set to default when value is null");
+});
+
 test("component has the correct class based on disabled value", function() {
   var component = buildComponent(this, { template: template1 });
 


### PR DESCRIPTION
If a toggle is created with `value` bound to a property that has the value `null`, the toggle is neither true or false and will render neither the true or false state.
