### PR TITLE
Popovers that align to parent now use the window to determine position

### DIFF
--- a/examples/tip.html
+++ b/examples/tip.html
@@ -27,6 +27,7 @@
     margin: 0;
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.3);
     transition: .15s opacity linear;
+    color: black;
   }
   lio-popover.active,
   lio-popover.activating {
@@ -81,6 +82,18 @@
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
+  }
+  .stamp lio-label {
+    color: white;
+    background: #666;
+    padding: 15px;
+    text-transform: uppercase;
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+  .stamp lio-popover {
+    white-space: nowrap;
   }
 </style>
 
@@ -143,6 +156,16 @@
 </div>
 
 <div class="box">
+  <div class="stamp">
+    {{#lio-tip activator="hover"}}
+      {{#lio-label}}
+        stamp
+      {{/lio-label}}
+      {{#lio-popover position="top"}}
+        This should have busted right out of the box
+      {{/lio-popover}}
+    {{/lio-tip}}
+  </div>
   <div class="inner-box">
   <p>In et lacus augue.
       {{#lio-tip activator="hover"}}

--- a/packages/display/lib/popover.js
+++ b/packages/display/lib/popover.js
@@ -134,16 +134,16 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
 
   adjustPosition: function() {
     var position = get(this, 'position');
-    var dimensions = getProperties(this, 'offsetLeft', 'width', 'anchorWidth', 'windowWidth', 'offsetTop', 'height', 'anchorHeight', 'windowHeight');
+    var dimensions = getProperties(this, 'trueOffsetLeft', 'width', 'anchorWidth', 'windowWidth', 'trueOffsetTop', 'height', 'anchorHeight', 'windowHeight');
 
     // The rendered position is the opposite of the preferred position when there is no room where preferred
-    if (position == 'left' && dimensions.offsetLeft - dimensions.width < 0) {
+    if (position == 'left' && dimensions.trueOffsetLeft - dimensions.width < 0) {
       position = 'right';
-    } else if (position == 'right' && dimensions.offsetLeft + dimensions.width + dimensions.anchorWidth > dimensions.windowWidth) {
+    } else if (position == 'right' && dimensions.trueOffsetLeft + dimensions.width + dimensions.anchorWidth > dimensions.windowWidth) {
       position = 'left';
-    } else if (position == 'top' && dimensions.offsetTop - dimensions.height < 0) {
+    } else if (position == 'top' && dimensions.trueOffsetTop - dimensions.height < 0) {
       position = 'bottom';
-    } else if (position == 'bottom' && dimensions.offsetTop + dimensions.height + dimensions.anchorHeight > dimensions.windowHeight) {
+    } else if (position == 'bottom' && dimensions.trueOffsetTop + dimensions.height + dimensions.anchorHeight > dimensions.windowHeight) {
       position = 'top';
     }
 
@@ -155,12 +155,17 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
       var $el = this.$();
       var $arrow = $el.find('.arrow');
       var $anchor = $(get(this, 'anchor'));
-      var anchorOffset = get(this, 'alignToParent') ? $anchor.position() : $anchor.offset();
-      anchorOffset = anchorOffset || { top: 0, left: 0 };
+      var trueAnchorOffset = $anchor.offset();
+      var anchorOffset = get(this, 'alignToParent') ? $anchor.position() : trueAnchorOffset;
+      trueAnchorOffset || (trueAnchorOffset = { top: 0, left: 0});
+      anchorOffset || (anchorOffset = { top: 0, left: 0 });
 
       setProperties(this, {
         offsetTop: anchorOffset.top,
         offsetLeft: anchorOffset.left,
+
+        trueOffsetTop: trueAnchorOffset.top,
+        trueOffsetLeft: trueAnchorOffset.left,
 
         windowWidth: $(window).width(),
         windowHeight: $(window).height(),

--- a/packages/display/tests/popover.js
+++ b/packages/display/tests/popover.js
@@ -105,7 +105,9 @@ test("the arrow position is centered on the popover", function() {
 
     giveBounds(component, {
       offsetTop: 500,
-      offsetLeft: 500
+      offsetLeft: 500,
+      trueOffsetTop: 500,
+      trueOffsetLeft: 500
     });
     component.adjustPosition();
     component.positioners[component.get('renderedPosition')](component);
@@ -139,7 +141,9 @@ test("the arrow position is centered on the popover", function() {
 
     giveBounds(component, {
       offsetTop: 500,
-      offsetLeft: 500
+      offsetLeft: 500,
+      trueOffsetTop: 500,
+      trueOffsetLeft: 500
     });
     component.adjustPosition();
     component.positioners[component.get('renderedPosition')](component);
@@ -160,7 +164,9 @@ test("the arrow position is centered on the popover", function() {
 
     giveBounds(component, {
       offsetTop: 800,
-      offsetLeft: 500
+      offsetLeft: 500,
+      trueOffsetTop: 800,
+      trueOffsetLeft: 500
     });
     component.adjustPosition();
     component.positioners[component.get('renderedPosition')](component);
@@ -183,7 +189,8 @@ test("the tooltip is repositioned when the window resizes", function() {
   Ember.run(function() {
     component.send('activate');
     giveBounds(component, {
-      offsetTop: 1337
+      offsetTop: 1337,
+      trueOffsetTop: 1337
     });
 
     component.adjustPosition();
@@ -192,7 +199,28 @@ test("the tooltip is repositioned when the window resizes", function() {
     $(window).trigger('resize');
     notEqual(component.get('offsetTop'), 1337);
   });
+});
 
+test("the tooltip does not flip when the offset to the parent is too small but the true offset is not too small", function() {
+  var component = buildComponent(this, {
+    layout: compileTemplate(defaultTemplate),
+    position: 'top'
+  });
+
+  $('<div id="anchor">').appendTo('#ember-testing');
+  component.set('anchor', '#anchor');
+
+  Ember.run(function() {
+    component.send('activate');
+    giveBounds(component, {
+      offsetTop: 5,
+      trueOffsetTop: 500
+    });
+
+    component.adjustPosition();
+    equal(component.get('position'), 'top');
+    equal(component.get('renderedPosition'), 'top');
+  });
 });
 
 function defaultTemplate() {/*
@@ -203,6 +231,9 @@ function giveBounds(component, overrides) {
   component.setProperties(Ember.merge({
     offsetTop: 10,
     offsetLeft: 10,
+
+    trueOffsetTop: 10,
+    trueOffsetLeft: 10,
 
     windowWidth: 1000,
     windowHeight: 1000,


### PR DESCRIPTION
Rather than using the bounds of the relative parent to determine whether
or not there is room for a popover to be positioned where intended,
use the full window dimensions.

A limitation to this is the behavior of text line-wrapping, which is
always based on the elements parent.
