### PR TITLE
Popover position adjustments should consider the document scroll position

### DIFF
--- a/examples/tip.html
+++ b/examples/tip.html
@@ -172,7 +172,7 @@
         {{#lio-label}}
           <cite tabindex=1>Fusce et tempus nunc, ac feugiat leo. Curabitur dignissim</cite>
         {{/lio-label}}
-        {{#lio-popover position="right"}}
+        {{#lio-popover position="bottom"}}
           I am not sure what that means. Sorry.
         {{/lio-popover}}
       {{/lio-tip}}

--- a/packages/display/lib/popover.js
+++ b/packages/display/lib/popover.js
@@ -166,6 +166,8 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
       trueAnchorOffset || (trueAnchorOffset = { top: 0, left: 0});
       anchorOffset || (anchorOffset = { top: 0, left: 0 });
 
+      trueAnchorOffset.top -= $(document).scrollTop();
+
       setProperties(this, {
         offsetTop: anchorOffset.top,
         offsetLeft: anchorOffset.left,


### PR DESCRIPTION
Everything below the ~~fold~~ gets its position adjusted to top (from bottom) because it is calculated as past the screen.

This fixes it by accounting for the scroll position of the document.
