### PR TITLE
Add support for diagonal/corner positioning of popovers

### DIFF
--- a/examples/popover.html
+++ b/examples/popover.html
@@ -36,7 +36,8 @@
     top: 50%;
     left: 0;
     right: 0;
-    margin: -50px auto 0;
+    margin: 0 auto;
+    transform: translateY(-50%);
     width: 150px;
     text-align: center;
   }
@@ -55,12 +56,13 @@
   .links .right {
     top: 50%;
     right: 0;
-    margin-top:-50px;
+    transform: translateY(-50%);
+    text-align: right;
   }
   .links .left {
     top: 50%;
     left: 0;
-    margin-top:-50px;
+    transform: translateY(-50%);
   }
   .links .bottom {
     text-align: center;
@@ -101,6 +103,10 @@
       <cite id="cite4" {{action 'togglePopover' 4}}>Left</cite>
       <cite id="cite2" {{action 'togglePopover' 2}}>Right</cite>
       <cite id="cite3" {{action 'togglePopover' 3}}>Bottom</cite>
+      <cite id="cite21" {{action 'togglePopover' 21}}>Top Left</cite>
+      <cite id="cite22" {{action 'togglePopover' 22}}>Top Right</cite>
+      <cite id="cite23" {{action 'togglePopover' 23}}>Bottom Left</cite>
+      <cite id="cite24" {{action 'togglePopover' 24}}>Bottom Right</cite>
     </div>
 
     <div class="top">
@@ -194,6 +200,19 @@
     <span>Here are the contents of the tooltip. I hope this is enough of a demonstration</span>
   {{/lio-popover}}
   {{#lio-popover anchor="#cite20" active=active20 position="left"}}
+    <span>Here are the contents of the tooltip. I hope this is enough of a demonstration</span>
+  {{/lio-popover}}
+
+  {{#lio-popover anchor="#cite21" active=active21 position="top-left"}}
+    <span>Here are the contents of the tooltip. I hope this is enough of a demonstration</span>
+  {{/lio-popover}}
+  {{#lio-popover anchor="#cite22" active=active22 position="top-right"}}
+    <span>Here are the contents of the tooltip. I hope this is enough of a demonstration</span>
+  {{/lio-popover}}
+  {{#lio-popover anchor="#cite23" active=active23 position="bottom-left"}}
+    <span>Here are the contents of the tooltip. I hope this is enough of a demonstration</span>
+  {{/lio-popover}}
+  {{#lio-popover anchor="#cite24" active=active24 position="bottom-right"}}
     <span>Here are the contents of the tooltip. I hope this is enough of a demonstration</span>
   {{/lio-popover}}
 

--- a/packages/display/lib/popover.js
+++ b/packages/display/lib/popover.js
@@ -17,7 +17,7 @@ import {
 } from 'ember';
 
 var typeKey = 'popover';
-var positions = A([ 'top', 'right', 'bottom', 'left' ]);
+var positions = A([ 'top', 'right', 'bottom', 'left', 'top-left', 'top-right', 'bottom-left', 'bottom-right' ]);
 
 /**
   Popover Component
@@ -39,7 +39,7 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
 
   tagName: tagForType(typeKey),
 
-  classNameBindings: [ 'renderedPosition' ],
+  classNameBindings: [ 'positionClassName' ],
 
   //
   // Handlebars Attributes
@@ -60,6 +60,11 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
   canBeTopLevel: true,
 
   renderedPosition: null,
+
+  positionClassName: computed(function() {
+    var position = get(this, 'renderedPosition');
+    return position && position.replace('-', ' ');
+  }).property('renderedPosition'),
 
   position: computed(function(key, value) {
     if (arguments.length === 1) {
@@ -112,6 +117,38 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
         offsetLeft: get(popover, 'offsetLeft') - get(popover, 'width') - get(popover, 'arrowWidth'),
         arrowOffsetLeft: get(popover, 'width')
       });
+    },
+    'top-left': function(popover) {
+      setProperties(popover, {
+        offsetTop: get(popover, 'offsetTop') - get(popover, 'height') - get(popover, 'arrowHeight'),
+        arrowOffsetTop: get(popover, 'height'),
+        offsetLeft: get(popover, 'offsetLeft') - get(popover, 'arrowWidth'),
+        arrowOffsetLeft: 0
+      });
+    },
+    'top-right': function(popover) {
+      setProperties(popover, {
+        offsetTop: get(popover, 'offsetTop') - get(popover, 'height') - get(popover, 'arrowHeight'),
+        arrowOffsetTop: get(popover, 'height'),
+        offsetLeft: get(popover, 'offsetLeft') - get(popover, 'width') + get(popover, 'anchorWidth'),
+        arrowOffsetLeft: get(popover, 'width') - get(popover, 'arrowWidth')
+      });
+    },
+    'bottom-left': function(popover) {
+      setProperties(popover, {
+        offsetTop: get(popover, 'offsetTop') + get(popover, 'anchorHeight') + get(popover, 'arrowHeight'),
+        arrowOffsetTop: 0 - get(popover, 'arrowHeight'),
+        offsetLeft: get(popover, 'offsetLeft') - get(popover, 'arrowWidth'),
+        arrowOffsetLeft: 0
+      });
+    },
+    'bottom-right': function(popover) {
+      setProperties(popover, {
+        offsetTop: get(popover, 'offsetTop') + get(popover, 'anchorHeight') + get(popover, 'arrowHeight'),
+        arrowOffsetTop: 0 - get(popover, 'arrowHeight'),
+        offsetLeft: get(popover, 'offsetLeft') - get(popover, 'width') + get(popover, 'anchorWidth'),
+        arrowOffsetLeft: get(popover, 'width') - get(popover, 'arrowWidth')
+      });
     }
   },
 
@@ -143,14 +180,14 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
     var dimensions = getProperties(this, 'trueOffsetLeft', 'width', 'anchorWidth', 'windowWidth', 'trueOffsetTop', 'height', 'anchorHeight', 'windowHeight');
 
     // The rendered position is the opposite of the preferred position when there is no room where preferred
-    if (position == 'left' && dimensions.trueOffsetLeft - dimensions.width < 0) {
-      position = 'right';
-    } else if (position == 'right' && dimensions.trueOffsetLeft + dimensions.width + dimensions.anchorWidth > dimensions.windowWidth) {
-      position = 'left';
-    } else if (position == 'top' && dimensions.trueOffsetTop - dimensions.height < 0) {
-      position = 'bottom';
-    } else if (position == 'bottom' && dimensions.trueOffsetTop + dimensions.height + dimensions.anchorHeight > dimensions.windowHeight) {
-      position = 'top';
+    if (position.indexOf('left') !== -1 && dimensions.trueOffsetLeft - dimensions.width < 0) {
+      position = position.replace('left', 'right');
+    } else if (position.indexOf('right') !== -1 && dimensions.trueOffsetLeft + dimensions.width + dimensions.anchorWidth > dimensions.windowWidth) {
+      position = position.replace('right', 'left');
+    } else if (position.indexOf('top') !== -1 && dimensions.trueOffsetTop - dimensions.height < 0) {
+      position = position.replace('top', 'bottom');
+    } else if (position.indexOf('bottom') !== -1 && dimensions.trueOffsetTop + dimensions.height + dimensions.anchorHeight > dimensions.windowHeight) {
+      position = position.replace('bottom', 'top');
     }
 
     set(this, 'renderedPosition', position);

--- a/packages/display/tests/popover.js
+++ b/packages/display/tests/popover.js
@@ -92,6 +92,27 @@ test("className is based off the rendered position", function() {
   });
 });
 
+test("corner positions result in two position class names (matching the edges)", function() {
+  var component = buildComponent(this, {
+    layout: compileTemplate(defaultTemplate)
+  });
+
+  $('<div id="anchor">').appendTo('#ember-testing');
+  component.set('anchor', '#anchor');
+
+  Ember.run(function() {
+    component.send('acivate');
+    component.set('position', 'top-left');
+    giveBounds(component);
+    component.adjustPosition();
+    equal(component.get('renderedPosition'), 'top-right');
+    Ember.run.next(function() {
+      ok(component.$().hasClass('right'));
+      ok(component.$().hasClass('top'));
+    });
+  });
+});
+
 test("the arrow position is centered on the popover", function() {
   var component = buildComponent(this, {
     layout: compileTemplate(defaultTemplate)


### PR DESCRIPTION
top-left, top-right, bottom-left, and bottom-right.

Unfortunately, these corner positions are not the combination of their components.

![screen shot 2014-11-21 at 12 24 21 pm](https://cloud.githubusercontent.com/assets/174740/5149043/95827966-7179-11e4-84fc-33c1bb9f6db1.png)
