### PR TITLE
Revert position flipping to just cardinal directions

### DIFF
--- a/packages/display/lib/popover.js
+++ b/packages/display/lib/popover.js
@@ -180,14 +180,15 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
     var dimensions = getProperties(this, 'trueOffsetLeft', 'width', 'anchorWidth', 'windowWidth', 'trueOffsetTop', 'height', 'anchorHeight', 'windowHeight');
 
     // The rendered position is the opposite of the preferred position when there is no room where preferred
-    if (position.indexOf('left') !== -1 && dimensions.trueOffsetLeft - dimensions.width < 0) {
-      position = position.replace('left', 'right');
-    } else if (position.indexOf('right') !== -1 && dimensions.trueOffsetLeft + dimensions.width + dimensions.anchorWidth > dimensions.windowWidth) {
-      position = position.replace('right', 'left');
-    } else if (position.indexOf('top') !== -1 && dimensions.trueOffsetTop - dimensions.height < 0) {
-      position = position.replace('top', 'bottom');
-    } else if (position.indexOf('bottom') !== -1 && dimensions.trueOffsetTop + dimensions.height + dimensions.anchorHeight > dimensions.windowHeight) {
-      position = position.replace('bottom', 'top');
+    // NOTE: this does not affect corner positions
+    if (position == 'left' && dimensions.trueOffsetLeft - dimensions.width < 0) {
+      position = 'right';
+    } else if (position == 'right' && dimensions.trueOffsetLeft + dimensions.width + dimensions.anchorWidth > dimensions.windowWidth) {
+      position = 'left';
+    } else if (position == 'top' && dimensions.trueOffsetTop - dimensions.height < 0) {
+      position = 'bottom';
+    } else if (position == 'bottom' && dimensions.trueOffsetTop + dimensions.height + dimensions.anchorHeight > dimensions.windowHeight) {
+      position = 'top';
     }
 
     set(this, 'renderedPosition', position);

--- a/packages/display/tests/popover.js
+++ b/packages/display/tests/popover.js
@@ -105,9 +105,9 @@ test("corner positions result in two position class names (matching the edges)",
     component.set('position', 'top-left');
     giveBounds(component);
     component.adjustPosition();
-    equal(component.get('renderedPosition'), 'top-right');
+    equal(component.get('renderedPosition'), 'top-left');
     Ember.run.next(function() {
-      ok(component.$().hasClass('right'));
+      ok(component.$().hasClass('left'));
       ok(component.$().hasClass('top'));
     });
   });


### PR DESCRIPTION
This removes the position flipping for corner positions (which were busted because the math is different).

I don't suspect dynamic position flipping + corner positioning is a practical use case. If it is, we can add the position flipping for them once it comes up.
