### PR TITLE
Improves the auto-closing of tip popovers.

### DIFF
--- a/packages/display/lib/tip.js
+++ b/packages/display/lib/tip.js
@@ -2,6 +2,7 @@ import { tagForType } from '../namespace';
 import ParentComponentMixin from '../mixin/parent';
 import ActiveStateMixin from '../mixin/active-state';
 import {
+  A,
   Component,
   Object,
   String,
@@ -103,12 +104,6 @@ export default Component.extend(ParentComponentMixin, ActiveStateMixin, {
     return get(this, 'shouldBubble');
   },
 
-  focusOut: function() {
-    set(this, 'fromFocus', false);
-    this.send('deactivate');
-    return get(this, 'shouldBubble');
-  },
-
   keyPress: function(event) {
     if (event.which === 13) {
       this.send('toggleActive');
@@ -132,5 +127,25 @@ export default Component.extend(ParentComponentMixin, ActiveStateMixin, {
 
     set(get(this, 'popover'), 'anchor', get(this, 'label').$());
     set(get(this, 'popover'), 'alignToParent', true);
+
+    var component = this;
+    var handler = function(event) {
+      if (component.get('active') && !withinComponent(event.target, component.$().add(component.get('anchor')))) {
+        component.set('active', false);
+      }
+    };
+
+    this.set('windowClickHandler', handler);
+    $(window).on('click.lio', handler);
+  },
+
+  willDestroyElement: function() {
+    $(window).off('click.lio', this.get('windowClickHandler'));
   }
 });
+
+function withinComponent(target, $elements) {
+  return A($elements.toArray()).any(function(el) {
+    return target === el || $.contains(el, target);
+  });
+}

--- a/packages/display/tests/tip.js
+++ b/packages/display/tests/tip.js
@@ -4,7 +4,15 @@ moduleForComponent('lio-tip', 'TipComponent', {
   needs: [
     'component:lio-label',
     'component:lio-popover'
-  ]
+  ],
+  teardown: function() {
+    // This happens in the willDestroyElement hook of the tip component, but
+    // ember-qunit, being the leading the ember test adapter, doesn't yet
+    // destroy views on teardown
+    //
+    // Look for that in ember-qunit v0.2.0! Yay?
+    $(window).off('click.lio');
+  }
 });
 
 test("component has correct tag name", function() {
@@ -63,8 +71,10 @@ test("it is not active when blurred", function() {
     active: true
   });
 
-  component.$('lio-label').focusout();
-  ok(!component.get('active'));
+  Ember.run(function() {
+    component.$().parent().simulate('click');
+    ok(!component.get('active'));
+  });
 });
 
 test("the popover is open when active", function() {


### PR DESCRIPTION
Using blurred means you can't click anything in the popover without
the popover closing, and events stopping before bubbling to the links
in the popover.

A `window` click handler works much better.
