### PR TITLE
Prevent temp files from being published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 bower_components/
 tests/
+tmp/
 
 .bowerrc
 .editorconfig


### PR DESCRIPTION
The `tmp/` dir got published on the last version bump, hopefully this will prevent that from happening again.