### PR TITLE
Racey toggle

### DIFF
--- a/addon/components/lio-toggle.js
+++ b/addon/components/lio-toggle.js
@@ -72,12 +72,7 @@ export default Component.extend(ParentComponentMixin, {
         run(this, function() {
           var current = get(this, 'value');
           var possible = get(this, 'possibleValues');
-          var nextIndex = possible.indexOf(current) + 1;
-
-          // Wrap around to the first value
-          if (nextIndex === get(possible, 'length')) {
-            nextIndex = 0;
-          }
+          var nextIndex = (possible.indexOf(current) + 1) % get(possible, 'length');
 
           set(this, 'value', possible[nextIndex]);
         });

--- a/addon/components/lio-toggle.js
+++ b/addon/components/lio-toggle.js
@@ -62,16 +62,23 @@ export default Component.extend(ParentComponentMixin, {
     return this.componentsForType('option').mapBy('value');
   }).property('components.[]'),
 
+  isTransitioning: function() {
+    return this.componentsForType('option').some(function(component) {
+      return get(component, 'isTransitioning');
+    });
+  }.property('components.@each.isTransitioning'),
+
   //
   // Internal Actions
   //
 
   actions: {
     toggle: function() {
-      if (!get(this, 'disabled')) {
+      if (!(get(this, 'disabled') || this.get('isTransitioning'))) {
         run(this, function() {
           var current = get(this, 'value');
           var possible = get(this, 'possibleValues');
+
           var nextIndex = (possible.indexOf(current) + 1) % get(possible, 'length');
 
           set(this, 'value', possible[nextIndex]);

--- a/addon/components/lio-toggle.js
+++ b/addon/components/lio-toggle.js
@@ -62,11 +62,11 @@ export default Component.extend(ParentComponentMixin, {
     return this.componentsForType('option').mapBy('value');
   }).property('components.[]'),
 
-  isTransitioning: function() {
+  isTransitioning: computed(function() {
     return this.componentsForType('option').some(function(component) {
       return get(component, 'isTransitioning');
     });
-  }.property('components.@each.isTransitioning'),
+  }).property('components.@each.isTransitioning'),
 
   //
   // Internal Actions


### PR DESCRIPTION
In my classic style, I was able to find a bug in the toggle component by drinking a bunch of coffee and clicking spastically on it. The parent component was handling the state, but it was not aware of the child component's transitioning state. This PR simply prevents the toggle action from firing again while the child component is still in transition from the last toggle action.

While I was reading the code, I found a place where a remainder was being calculated manually, and I incidentally changed it to use the remainder operator instead since I was editing this file anyway.

The build is failing, but I looked into it, and it seems to be the same test that has been failing for about 2 months, so I'm confident that my patch is not the cause of the regression.