### PR TITLE
Revert the withTransition callback in the activeState mixin

### DIFF
--- a/addon/components/lio-popover.js
+++ b/addon/components/lio-popover.js
@@ -265,7 +265,23 @@ export default Component.extend(ParentComponentMixin, ChildComponentMixin, Activ
     const dimensions = getProperties(this, 'arrowOffsetTop', 'offsetTop', 'height', 'anchorHeight', 'windowHeight');
     set(this, 'offsetTop', adjustForEdges(dimensions.offsetTop, dimensions.height, dimensions.anchorHeight, dimensions.windowHeight));
     set(this, 'arrowOffsetTop', adjustArrowForEdges(dimensions.arrowOffsetTop, dimensions.offsetTop, dimensions.height, dimensions.anchorHeight, dimensions.windowHeight));
-  }
+  },
+
+  //
+  // Mixin Overrides
+  //
+
+  transitionVisualState: observer('isActive', function() {
+    const isActive = this.get('isActive');
+
+    // Immediately set flip the isVisuallyActive flag to avoid timing bugs
+    set(this, 'isVisuallyActive', isActive);
+
+    // The component may not use transitions
+    if (this.withTransition) {
+      this.withTransition(isActive ? 'activating' : 'deactivating');
+    }
+  })
 });
 
 // Given the bounding dimensions, return the origin top/left component that keeps the popover in the frame

--- a/addon/mixins/active-state.js
+++ b/addon/mixins/active-state.js
@@ -65,8 +65,9 @@ export default Mixin.create({
 
     // The component may not use transitions
     if (this.withTransition) {
-      set(this, 'isVisuallyActive', isActive);
-      this.withTransition(isActive ? 'activating' : 'deactivating');
+      this.withTransition(isActive ? 'activating' : 'deactivating', function() {
+        set(this, 'isVisuallyActive', isActive);
+      });
     } else {
       set(this, 'isVisuallyActive', isActive);
     }


### PR DESCRIPTION
And override it in popover, where the change is beneficial.

The change this reverts breaks certain implementations of preexisting components. Namely `lio-toggle`.
